### PR TITLE
Render external nav links with icon and target=_blank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+pkg/
+jekyll-theme-isotc211-*.gem

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,11 @@
         <ul class="site-footer__links">
           {% if site.nav %}
             {% for item in site.nav %}
+            {% if item.url contains "://" %}
+          <li><a href="{{ item.url }}" class="site-footer__link" target="_blank" rel="noopener">{{ item.title }}</a></li>
+            {% else %}
           <li><a href="{{ item.url | relative_url }}" class="site-footer__link">{{ item.title }}</a></li>
+            {% endif %}
             {% endfor %}
           {% endif %}
           {% if site.committee.home %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,14 @@
       {% if site.nav %}
       <nav class="site-header__nav">
         {% for item in site.nav %}
+        {% if item.url contains "://" %}
+        <a href="{{ item.url }}" class="site-header__link" target="_blank" rel="noopener">
+          {{ item.title }}
+          <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6m0 0v6m0-6L10 14"/></svg>
+        </a>
+        {% else %}
         <a href="{{ item.url | relative_url }}" class="site-header__link">{{ item.title }}</a>
+        {% endif %}
         {% endfor %}
       </nav>
       {% endif %}


### PR DESCRIPTION
Nav items with `://` in their URL now get the same external-link treatment as the Committee Site link: external arrow icon, `target=_blank`, `rel=noopener`.\n\nInternal nav items remain unchanged.\n\nNeeded by ISO-TC211/standards.isotc211.org#9.